### PR TITLE
SEC-651: Vigiles: Add ability to read API credentials from environment

### DIFF
--- a/classes/vigiles.bbclass
+++ b/classes/vigiles.bbclass
@@ -737,6 +737,7 @@ python do_vigiles_check() {
         # original shell environment, but still passing the local.conf values on
         # the command line -- for compatibility with other Vigiles implementations.
         _orig_env = d.getVar('BB_ORIGENV', False)
+        vigiles_env['VIGILES_API_CREDENTIALS'] = _orig_env.getVar('VIGILES_API_CREDENTIALS') or ''
         vigiles_env['VIGILES_KEY_FILE'] = _orig_env.getVar('VIGILES_KEY_FILE') or ''
         vigiles_env['VIGILES_DASHBOARD_CONFIG'] = _orig_env.getVar('VIGILES_DASHBOARD_CONFIG') or ''
         vigiles_env['VIGILES_SUBFOLDER_NAME'] = _orig_env.getVar('VIGILES_SUBFOLDER_NAME') or ''

--- a/scripts/checkcves.py
+++ b/scripts/checkcves.py
@@ -258,6 +258,8 @@ def _get_credentials(kf_param, dc_param, sf_param):
     home_dir = os.path.expanduser('~')
     timesys_dir  = os.path.join(home_dir, 'timesys')
 
+    c_env = os.getenv('VIGILES_API_CREDENTIALS', '')
+
     kf_env = os.getenv('VIGILES_KEY_FILE', '')
     kf_default = os.path.join(timesys_dir, 'linuxlink_key')
 
@@ -267,7 +269,9 @@ def _get_credentials(kf_param, dc_param, sf_param):
     sf_env = os.getenv('VIGILES_SUBFOLDER_NAME', '')
     sf_default = ''
 
-    if kf_env:
+    if c_env:
+        print("Vigiles: Using LinixLink Credentials in Environment")
+    elif kf_env:
         print("Vigiles: Using LinuxLink Key from Environment: %s" % kf_env)
         key_file = kf_env
     elif kf_param:
@@ -298,7 +302,15 @@ def _get_credentials(kf_param, dc_param, sf_param):
         subfolder_name = sf_default
 
     try:
-        email, key = llapi.read_keyfile(key_file)
+        email, key = (None, None)
+
+        # If Vigiles API credentials are specified in the environment, they
+        # are used by default instead of the keyfile.
+        if c_env:
+            email, key = llapi.parse_credentials(c_env)
+        else:
+            email, key = llapi.read_keyfile(key_file)
+
         # It is fine if either of these are none, they will just default
         dashboard_tokens = llapi.read_dashboard_config(dashboard_config)
     except Exception as e:

--- a/scripts/lib/llapi.py
+++ b/scripts/lib/llapi.py
@@ -43,12 +43,17 @@ def read_keyfile(key_file):
         with open(key_file, 'r') as f:
             key_info = json.load(f)
     except (OSError, IOError, UnicodeDecodeError):
-            email, key = (None, None)
+        email, key = (None, None)
     except Exception:
         raise Exception("Unable to parse key file: %s" % key_file)
     else:
-        email = key_info.get('email', '').strip()
-        key = key_info.get('key', '').strip()
+        email, key = parse_credentials(key_info)
+
+    return (email, key)
+
+def parse_credentials(credentials):
+    email = credentials.get('email', '').strip()
+    key = credentials.get('key', '').strip()
 
     return (email, key)
 


### PR DESCRIPTION
### Purpose
We do not want to store the plaintext linuxlink_key file in our local file system. Instead, we want to be able to store the API credentials secretly, retrieve them, and use them. 

### Technical Overview
While possible to pull the secret directly from where we storage, we instead add the ability to read credentials from environment variables. This allows for retrieval to be decoupled from using the API credentials so it is compatible with whatever storage/retrieval mechanism of the key is used.


