### PR TITLE
SECSW-1027: Vigiles: Fix reading API credentials from environment

### DIFF
--- a/scripts/checkcves.py
+++ b/scripts/checkcves.py
@@ -270,7 +270,7 @@ def _get_credentials(kf_param, dc_param, sf_param):
     sf_default = ''
 
     if c_env:
-        print("Vigiles: Using LinixLink Credentials in Environment")
+        print("Vigiles: Using LinuxLink Credentials in Environment")
     elif kf_env:
         print("Vigiles: Using LinuxLink Key from Environment: %s" % kf_env)
         key_file = kf_env

--- a/scripts/lib/llapi.py
+++ b/scripts/lib/llapi.py
@@ -52,6 +52,7 @@ def read_keyfile(key_file):
     return (email, key)
 
 def parse_credentials(credentials):
+    credentials = json.loads(credentials)
     email = credentials.get('email', '').strip()
     key = credentials.get('key', '').strip()
 


### PR DESCRIPTION
When the API credentials are read from an environment variable, convert them to a JSON to allow field retrieval.

Also, fix a typo.