### PR TITLE
SEN-2727: workflows: Fix vigiles key parsing

### DIFF
--- a/scripts/checkcves.py
+++ b/scripts/checkcves.py
@@ -307,7 +307,8 @@ def _get_credentials(kf_param, dc_param, sf_param):
         # If Vigiles API credentials are specified in the environment, they
         # are used by default instead of the keyfile.
         if c_env:
-            email, key = llapi.parse_credentials(c_env)
+            creds = json.loads(c_env)
+            email, key = llapi.parse_credentials(creds)
         else:
             email, key = llapi.read_keyfile(key_file)
 

--- a/scripts/lib/llapi.py
+++ b/scripts/lib/llapi.py
@@ -52,7 +52,6 @@ def read_keyfile(key_file):
     return (email, key)
 
 def parse_credentials(credentials):
-    credentials = json.loads(credentials)
     email = credentials.get('email', '').strip()
     key = credentials.get('key', '').strip()
 


### PR DESCRIPTION
Currently, `parse_credentials` function is used to parse key from env and file. This leads to errors when parsing key from file as the key there is already converted to a python dict whereas `parse_credentials` expects a string.

This commit reverts 38ee5cee, and performs dict conversion of env key before using `parse_credentials`.